### PR TITLE
add basic functionality for query strings in start and end date

### DIFF
--- a/date-range-ninja-forms.php
+++ b/date-range-ninja-forms.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/soderlind/date-range-ninja-forms
  * GitHub Plugin URI: https://github.com/soderlind/date-range-ninja-forms
  * Description: Add a Date Range field to your Ninja Forms.
- * Version:     0.2.0
+ * Version:     0.2.1
  * Author:      Per Soderlind
  * Author URI:  https://soderlind.no
  * Text Domain: date-range-ninja-forms
@@ -22,7 +22,7 @@
 
 namespace Soderlind\NinjaForms\DateRange;
 
-define( 'DR_VERSION_NUMBER', '0.2.0' );
+define( 'DR_VERSION_NUMBER', '0.2.1' );
 /**
  * Register Date Range field
  */

--- a/js/date-range.js
+++ b/js/date-range.js
@@ -195,8 +195,23 @@ document.addEventListener(
 				}
 
 				if (0 !== view.model.get("max_min_date")) {
-					const minMaxDateStart = view.model.get("min_date");
-					const minMaxDateEnd = view.model.get("max_date");
+					let minMaxDateStart = view.model.get("min_date");
+					let minMaxDateEnd = view.model.get("max_date");
+					const urlParams = new URLSearchParams(window.location.search);
+
+					// get the start date and check if its a query string
+					if (minMaxDateStart.includes('{querystring:')){
+						const qStringStart = minMaxDateStart.split(':')[1].replace('}', '');
+						const queryDateStart = urlParams.get(qStringStart);
+						if (queryDateStart) minMaxDateStart = urlParams.get(qStringStart);
+					}
+
+					// get the end date and check if its a query string
+					if (minMaxDateEnd.includes('{querystring:')){
+						const qStringEnd = minMaxDateEnd.split(':')[1].replace('}', '');
+						const queryDateEnd = urlParams.get(qStringEnd);
+						if (queryDateEnd) minMaxDateEnd = urlParams.get(qStringEnd);
+					}
 
 					if (typeof minMaxDateStart !== "undefined" && minMaxDateStart !== "") {
 						if (this.isValidDate(minMaxDateStart)) {


### PR DESCRIPTION
Ninja forms support query strings as values. This is a requirement for my use, so I hacked this together. 

I am willing to make a few changes if its needed, but most of all I'm making this pull request as I can imagine others might need the same query string functionality.

I am not a wordpress developer, so I am unsure if there is a different pre defined way we should be getting the url parameters, but this implementation works.